### PR TITLE
Add navigation to quiz attempt in QuizSection component

### DIFF
--- a/src/components/Group/QuizSection.tsx
+++ b/src/components/Group/QuizSection.tsx
@@ -15,6 +15,7 @@ import {
   PlayArrow,
   TrendingUp 
 } from '@mui/icons-material';
+import { useNavigate } from 'react-router-dom';
 
 interface QuizItem {
   id: string;
@@ -34,6 +35,7 @@ interface QuizSectionProps {
 
 const QuizSection = ({ groupId }: QuizSectionProps) => {
   console.log(groupId)
+  const navigate = useNavigate();
   const quizzes: QuizItem[] = [
     {
       id: '1',
@@ -248,6 +250,7 @@ const QuizSection = ({ groupId }: QuizSectionProps) => {
                       variant={quiz.completed ? "outlined" : "contained"}
                       startIcon={quiz.completed ? <CheckCircle /> : <PlayArrow />}
                       size={window.innerWidth < 600 ? "medium" : "small"}
+                      onClick={()=>{navigate(`/quiz/attempt/${quiz.id}`)}}
                       sx={{ 
                         minWidth: { xs: '100%', sm: 100 },
                         bgcolor: (theme) => quiz.completed ? 'transparent' : theme.palette.accent.quiz,


### PR DESCRIPTION
This pull request introduces navigation functionality to the quiz attempt flow in the `QuizSection` component. Now, when a user clicks the quiz action button, they will be routed to the quiz attempt page for the selected quiz.

**Routing enhancements:**

* Imported the `useNavigate` hook from `react-router-dom` in `QuizSection.tsx` to enable programmatic navigation.
* Initialized the `navigate` function using `useNavigate` inside the `QuizSection` component.
* Added an `onClick` handler to the quiz action button that navigates to the quiz attempt route for the selected quiz (`/quiz/attempt/{quiz.id}`).