### PR TITLE
Refactor Titlebar component by removing Chats icon; update UserDocuments to navigate to document editor on button click; adjust DocumentEditor dimensions; modify ProfilePage container for better responsiveness.

### DIFF
--- a/src/components/DocumentEditor/Titlebar.tsx
+++ b/src/components/DocumentEditor/Titlebar.tsx
@@ -223,7 +223,6 @@ export const Titlebar = () => {
                 spacing={{ sm: 0.5, md: 1 }}
                 sx={{ display: { xs: "none", sm: "none", md: "flex" } }}
               >
-                <Chats size="small" showTooltip={true} badgeContent={3} />
                 <NotificationsButton
                   size="small"
                   showTooltip={true}

--- a/src/components/UserDashboard/UserDocuments.tsx
+++ b/src/components/UserDashboard/UserDocuments.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   Box,
   useTheme,
@@ -124,6 +125,7 @@ const folders: Folder[] = [
 
 export const UserDocuments = () => {
   const theme = useTheme();
+  const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState("");
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -154,6 +156,10 @@ export const UserDocuments = () => {
     }
   };
 
+  const handleNewDocument = () => {
+    navigate("/document-editor");
+  };
+
   return (
     <Box
       sx={{
@@ -179,7 +185,7 @@ export const UserDocuments = () => {
               justifyContent: "space-between",
             }}
           >
-            <Box sx={{ display: "flex", alignItems: "center", gap: 2}}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
               <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                 <FileTextIcon
                   sx={{ fontSize: 28, color: theme.palette.primary.main }}
@@ -191,7 +197,11 @@ export const UserDocuments = () => {
             </Box>
 
             <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-              <Button variant="contained" startIcon={<PlusIcon />}>
+              <Button
+                variant="contained"
+                startIcon={<PlusIcon />}
+                onClick={handleNewDocument}
+              >
                 New Document
               </Button>
             </Box>

--- a/src/pages/DocumentEditor.tsx
+++ b/src/pages/DocumentEditor.tsx
@@ -217,7 +217,7 @@ export const DocumentEditor = () => {
         <Box
           sx={{
             width: "100%",
-            maxWidth: { xs: "100%", md: "8.5in" },
+            maxWidth: { xs: "100%", md: "10in" },
             position: "relative",
           }}
         >
@@ -295,8 +295,8 @@ export const DocumentEditor = () => {
                   transform: { xs: "none", lg: `scale(${zoomLevel / 100})` },
                   transformOrigin: "top center",
                   transition: "transform 0.2s ease-in-out",
-                  height: "850px",
-                  width: "650px",
+                  height: "950px",
+                  width: "750px",
                   aspectRatio: "8.5 / 11",
                   margin: "0 auto",
                   "&::before": {

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -54,7 +54,7 @@ export default function ProfilePage() {
   return (
     <Box>
       <Box sx={{ minHeight: "100vh", bgcolor: "background.default", py: 4 }}>
-        <Container maxWidth="md">
+        <Container>
           <Box sx={{ textAlign: "center", mb: 4 }}>
             <Typography variant="h4" fontWeight={700} gutterBottom>
               Profile Settings


### PR DESCRIPTION
This pull request introduces a new navigation behavior for creating documents, adjusts the UI layout for document editing, and makes a minor update to the profile page layout. The most significant change is enabling users to navigate directly to the document editor when clicking "New Document" from their dashboard.

**User Document Creation and Navigation:**
- Added navigation support in `UserDocuments` so that clicking the "New Document" button takes the user to the `/document-editor` route. This involved importing `useNavigate`, defining a handler, and wiring it to the button's `onClick` event. [[1]](diffhunk://#diff-baba3e508b0ca605f0fcf86306ff8633d2ca225081d7e1127e739e8641d2be38R2) [[2]](diffhunk://#diff-baba3e508b0ca605f0fcf86306ff8633d2ca225081d7e1127e739e8641d2be38R128) [[3]](diffhunk://#diff-baba3e508b0ca605f0fcf86306ff8633d2ca225081d7e1127e739e8641d2be38R159-R162) [[4]](diffhunk://#diff-baba3e508b0ca605f0fcf86306ff8633d2ca225081d7e1127e739e8641d2be38L194-R204)

**UI and Layout Adjustments:**
- Increased the maximum width of the document editor on medium screens from `8.5in` to `10in`, and adjusted the document canvas size from `650x850px` to `750x950px` for a larger editing area. [[1]](diffhunk://#diff-ebc0807f7fb0d5f5ae199e7e81e5aac22ec7b367a7d43afa544c401ed9139861L220-R220) [[2]](diffhunk://#diff-ebc0807f7fb0d5f5ae199e7e81e5aac22ec7b367a7d43afa544c401ed9139861L298-R299)
- Removed the `Chats` button from the `Titlebar` component, likely to declutter the interface.

**Profile Page Layout:**
- Changed the `Container` in `ProfilePage` to use the default width instead of `maxWidth="md"`, allowing for a potentially wider layout.