### PR TITLE
Redirect tutors to user dashboard after sign-in

### DIFF
--- a/src/pages/signIn/SignInPage.tsx
+++ b/src/pages/signIn/SignInPage.tsx
@@ -114,7 +114,7 @@ export default function SignInPage() {
                 } else {
                   if (response.data.role === "user") navigate("/user-dashboard");
                   else if (response.data.role === "admin") navigate("/admin-dashboard");
-                  else if (response.data.role === "tutor") navigate("/tutor-dashboard");
+                  else if (response.data.role === "tutor") navigate("/user-dashboard");
                 }
               }, 1000);
       } else {


### PR DESCRIPTION
This pull request makes a small but important change to the sign-in logic in `SignInPage.tsx`. Now, users with the "tutor" role are redirected to the user dashboard instead of the tutor dashboard after signing in.

* Updated the navigation logic so that when a user with the "tutor" role signs in, they are redirected to `/user-dashboard` instead of `/tutor-dashboard` in `SignInPage.tsx`.