### PR TITLE
Update navigation path after saving quiz to redirect to tutor dashboard

### DIFF
--- a/src/pages/quiz/Createquiz.tsx
+++ b/src/pages/quiz/Createquiz.tsx
@@ -217,7 +217,7 @@ export default function CreateQuizPage() {
     
     console.log("Saving quiz:", quiz);
     showAlert("success", "Quiz saved successfully!");
-    setTimeout(() => navigate("/user-dashboard"), 1500);
+    setTimeout(() => navigate("/tutor-dashboard"), 1500);
   };
 
   const handlePreviewQuiz = () => {


### PR DESCRIPTION
This pull request makes a minor update to the navigation behavior after saving a quiz. The destination route has been changed to direct users to the tutor dashboard instead of the user dashboard.

* Updated the post-save navigation in `CreateQuizPage` to redirect to `/tutor-dashboard` instead of `/user-dashboard`.