### PR TITLE
style/bug: Removed global .MuiBox-root overflow rule; now handled locally in Tiptap.tsx

### DIFF
--- a/src/components/DocumentEditor/Editor/Tiptap.tsx
+++ b/src/components/DocumentEditor/Editor/Tiptap.tsx
@@ -376,6 +376,7 @@ const Tiptap = ({
           boxSizing: "border-box",
           transition: "border-color 0.2s ease, box-shadow 0.2s ease",
           position: "relative",
+          overflowX: "hidden",
           "&:focus-within": {
             borderColor: theme.palette.primary.main,
             boxShadow:

--- a/src/styles/components/DocumentEditor/Tiptap.css
+++ b/src/styles/components/DocumentEditor/Tiptap.css
@@ -109,12 +109,6 @@
 
 /* Debug: Remove unwanted white divs */
 
-/* Ensure MUI components don't cause overflow */
-.MuiBox-root {
-  max-width: 100% !important;
-  overflow-x: hidden !important;
-}
-
 /* Override for toolbar-related boxes to prevent button clipping */
 .MuiAppBar-root .MuiBox-root,
 .MuiToolbar-root .MuiBox-root {


### PR DESCRIPTION
This pull request makes a minor adjustment to the Tiptap editor's styling to better handle horizontal overflow. The change moves the `overflow-x: hidden` rule from a global CSS override to an inline style on the Tiptap editor container itself, improving style encapsulation and reducing the risk of unintended side effects on other components.

- Editor container styling:
  * Added `overflowX: "hidden"` to the Tiptap editor container's inline styles in `Tiptap.tsx` to prevent horizontal overflow.
  * Removed the global CSS rule that set `overflow-x: hidden` on all `.MuiBox-root` elements in `Tiptap.css`, reducing the chance of interfering with unrelated Material UI components.